### PR TITLE
start app with preview video

### DIFF
--- a/src/js/actions.ts
+++ b/src/js/actions.ts
@@ -12,6 +12,7 @@ interface Action {
 }
 
 const actions: Action[] = [
+  // not bothering to include LiveVideo, since it's only meant to be used at the beginning
   {
     description: "Reset",
     keycode: "KeyR",

--- a/src/js/canvas.ts
+++ b/src/js/canvas.ts
@@ -32,6 +32,7 @@ export default class Canvas {
   }
 
   context() {
+    // TODO cache
     const ctx = this.el.getContext("2d");
     if (!ctx) {
       throw new Error("context couldn't be retrieved");

--- a/src/js/effects/effect.ts
+++ b/src/js/effects/effect.ts
@@ -1,5 +1,6 @@
 import { Pose } from "@tensorflow-models/pose-detection";
 import Canvas from "../canvas";
+import { getShoulderWidth } from "../skeleton";
 
 /**
  * @param effects gets modified
@@ -23,12 +24,11 @@ export const sortEfects = (currentPose: Pose, effects: Effect[]) => {
 };
 
 export default abstract class Effect {
-  abstract sortVal(currentPose: Pose): number | null;
   abstract onAnimationFrame(pose: Pose, canvas: Canvas): Promise<void>;
 
-  // unable to make an abstract static method
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  static addTo(_effects: Effect[]) {
-    throw new Error("Not implemented");
+  sortVal(currentPose: Pose) {
+    return getShoulderWidth(currentPose.keypoints);
   }
+
+  // each Effect should probably implement a `static addTo()` method; the signature can be whatever is necessary
 }

--- a/src/js/effects/live_video.ts
+++ b/src/js/effects/live_video.ts
@@ -1,0 +1,23 @@
+import { Pose } from "@tensorflow-models/pose-detection";
+import Canvas from "../canvas";
+import Video from "../video";
+import Effect from "./effect";
+
+export default class LiveVideo extends Effect {
+  video: Video;
+
+  constructor(video: Video) {
+    super();
+    this.video = video;
+  }
+
+  async onAnimationFrame(_pose: Pose, canvas: Canvas) {
+    const ctx = canvas.context();
+    ctx.drawImage(this.video.el, 0, 0);
+  }
+
+  static addTo(effects: Effect[], video: Video) {
+    const effect = new LiveVideo(video);
+    effects.unshift(effect);
+  }
+}

--- a/src/js/effects/live_video.ts
+++ b/src/js/effects/live_video.ts
@@ -11,6 +11,13 @@ export default class LiveVideo extends Effect {
     this.video = video;
   }
 
+  /**
+   * @returns an arbitrary low value, so that this effect always appears in the back
+   */
+  sortVal(_currentPose: Pose) {
+    return -1000;
+  }
+
   async onAnimationFrame(_pose: Pose, canvas: Canvas) {
     const ctx = canvas.context();
     ctx.drawImage(this.video.el, 0, 0);

--- a/src/js/effects/shadow.ts
+++ b/src/js/effects/shadow.ts
@@ -14,10 +14,6 @@ export default class Shadow extends Effect {
     this.color = colors.getNext();
   }
 
-  sortVal(currentPose: Pose) {
-    return getShoulderWidth(currentPose.keypoints);
-  }
-
   async onAnimationFrame(pose: Pose, canvas: Canvas) {
     if (pose?.segmentation) {
       await drawMask(pose.segmentation, canvas, this.color);

--- a/src/js/effects/shadow.ts
+++ b/src/js/effects/shadow.ts
@@ -2,7 +2,6 @@ import { Pose } from "@tensorflow-models/pose-detection";
 import { Color } from "@tensorflow-models/pose-detection/dist/shared/calculators/interfaces/common_interfaces";
 import Canvas from "../canvas";
 import { drawMask } from "../segment_helpers";
-import { getShoulderWidth } from "../skeleton";
 import Effect from "./effect";
 import * as colors from "../colors";
 

--- a/src/js/index.ts
+++ b/src/js/index.ts
@@ -56,6 +56,10 @@ const setup = async () => {
   // start with a Shadow
   Shadow.addTo(effects);
 
+  // add preview video
+  const container = getElementById("container");
+  container.appendChild(video.el);
+
   window.addEventListener("error", (event) => onPageError(event, detector));
 
   // kick off the video display

--- a/src/js/index.ts
+++ b/src/js/index.ts
@@ -6,11 +6,11 @@ import Detector from "./detector";
 import { getElementById } from "./dom_helpers";
 import Effect from "./effects/effect";
 import { actionForKeyCode } from "./actions";
-import Shadow from "./effects/shadow";
 import "./controls";
 import { onAnimationFrame } from "./loop";
 import { handleVisibilityChanges } from "./visibility";
 import { setupFullscreen } from "./fullscreen";
+import LiveVideo from "./effects/live_video";
 
 const showFPS = (stats: Stats) => {
   stats.showPanel(0);
@@ -53,12 +53,8 @@ const setup = async () => {
   const stats = new Stats();
   const detector = new Detector(video);
   const effects: Effect[] = [];
-  // start with a Shadow
-  Shadow.addTo(effects);
-
-  // add preview video
-  const container = getElementById("container");
-  container.appendChild(video.el);
+  // start with live video
+  LiveVideo.addTo(effects, video);
 
   window.addEventListener("error", (event) => onPageError(event, detector));
 

--- a/src/js/skeleton.ts
+++ b/src/js/skeleton.ts
@@ -27,7 +27,7 @@ const hypotenuse = (a: Keypoint, b: Keypoint) => {
 };
 
 /**
- * @returns the shoulder width, expected to be in the 50-200 range
+ * @returns the shoulder width, expected to be in the 100-1000 range
  */
 export const getShoulderWidth = (keypoints: Keypoint[]) => {
   const leftShoulder = keypoints.find((kp) => kp.name === "left_shoulder");


### PR DESCRIPTION
Should make camera placement easier, and falsely set expectations with the audience that the projection/app is going to just be a live projection.