### PR TITLE
do better depth calculation

### DIFF
--- a/src/js/effects/cannon.ts
+++ b/src/js/effects/cannon.ts
@@ -3,7 +3,7 @@ import { Color } from "@tensorflow-models/pose-detection/dist/shared/calculators
 import Canvas from "../display/canvas";
 import { MaxSizeQueue } from "../utils/queue";
 import { drawSkeleton } from "../utils/segment_helpers";
-import { getShoulderWidth } from "../utils/math";
+import { getAverageDepth } from "../utils/math";
 import Effect from "./effect";
 import * as colors from "../utils/colors";
 
@@ -51,7 +51,7 @@ export default class Cannon extends Effect {
     if (!oldPose) {
       return null;
     }
-    return getShoulderWidth(oldPose.keypoints);
+    return getAverageDepth(oldPose.keypoints);
   }
 
   async onAnimationFrame(pose: Pose, canvas: Canvas) {

--- a/src/js/effects/effect.ts
+++ b/src/js/effects/effect.ts
@@ -1,6 +1,6 @@
 import { Pose } from "@tensorflow-models/pose-detection";
 import Canvas from "../display/canvas";
-import { getShoulderWidth } from "../utils/math";
+import { getAverageDepth } from "../utils/math";
 
 /**
  * @param effects gets modified
@@ -27,7 +27,7 @@ export default abstract class Effect {
   abstract onAnimationFrame(pose: Pose, canvas: Canvas): Promise<void>;
 
   sortVal(currentPose: Pose) {
-    return getShoulderWidth(currentPose.keypoints);
+    return getAverageDepth(currentPose.keypoints);
   }
 
   // each Effect should probably implement a `static addTo()` method; the signature can be whatever is necessary

--- a/src/js/effects/freeze.ts
+++ b/src/js/effects/freeze.ts
@@ -2,7 +2,7 @@ import { Pose } from "@tensorflow-models/pose-detection";
 import { Color } from "@tensorflow-models/pose-detection/dist/shared/calculators/interfaces/common_interfaces";
 import Canvas from "../display/canvas";
 import { drawSkeleton } from "../utils/segment_helpers";
-import { getShoulderWidth } from "../utils/math";
+import { getAverageDepth } from "../utils/math";
 import Effect from "./effect";
 import * as colors from "../utils/colors";
 
@@ -19,7 +19,7 @@ export default class Freeze extends Effect {
     if (!this.frame) {
       return null;
     }
-    return getShoulderWidth(this.frame.keypoints);
+    return getAverageDepth(this.frame.keypoints);
   }
 
   async onAnimationFrame(pose: Pose, canvas: Canvas) {

--- a/src/js/utils/math.ts
+++ b/src/js/utils/math.ts
@@ -1,14 +1,17 @@
 import { Keypoint } from "@tensorflow-models/pose-detection";
 import { mean } from "lodash";
 
+// https://google.github.io/mediapipe/solutions/pose.html#pose-landmark-model-blazepose-ghum-3d
+const useForDepth = (keypoint: Keypoint) =>
+  keypoint.z && keypoint.name && /_(hip|shoulder)$/.test(keypoint.name);
+
 /**
  * @returns the average keypoint depth, expected to be in the 0.05 (far from camera) to 1.2 (close to camera) range
  */
 export const getAverageDepth = (keypoints: Keypoint[]) => {
+  const keypointsToUse = keypoints.filter(useForDepth);
   // the mean() type signature is wrong
-  const avg = mean(keypoints.filter((kp) => kp.z).map((kp) => kp.z)) as
-    | number
-    | null;
+  const avg = mean(keypointsToUse.map((kp) => kp.z)) as number | null;
   if (!avg) {
     return null;
   }

--- a/src/js/utils/math.ts
+++ b/src/js/utils/math.ts
@@ -6,7 +6,16 @@ const useForDepth = (keypoint: Keypoint) =>
   keypoint.z && keypoint.name && /_(hip|shoulder)$/.test(keypoint.name);
 
 /**
- * @returns the average keypoint depth, expected to be in the 0.05 (far from camera) to 1.2 (close to camera) range
+ * far from the camera
+ */
+const DEPTH_MIN = 0.05;
+/**
+ * close to the camera
+ */
+const DEPTH_MAX = 0.8;
+
+/**
+ * @returns the average keypoint depth, expected to be in the range defined by DEPTH_MIN and DEPTH_MAX
  */
 export const getAverageDepth = (keypoints: Keypoint[]) => {
   const keypointsToUse = keypoints.filter(useForDepth);
@@ -36,6 +45,7 @@ const scale = (
  */
 export const calculateLineWidth = (keypoints: Keypoint[]) => {
   const depth = getAverageDepth(keypoints);
+  console.log(depth);
 
   // somewhat arbitrary values
 
@@ -43,10 +53,16 @@ export const calculateLineWidth = (keypoints: Keypoint[]) => {
     return 6;
   }
 
-  const DEPTH_MIN = 0.05;
-  const DEPTH_MAX = 1.2;
-  const LINE_WIDTH_MIN = 1;
-  const LINE_WIDTH_MAX = 100;
+  const LINE_WIDTH_MIN = 3;
+  const LINE_WIDTH_MAX = 150;
 
-  return scale(depth, DEPTH_MIN, DEPTH_MAX, LINE_WIDTH_MIN, LINE_WIDTH_MAX);
+  const width = scale(
+    depth,
+    DEPTH_MIN,
+    DEPTH_MAX,
+    LINE_WIDTH_MIN,
+    LINE_WIDTH_MAX
+  );
+  // don't go below the minimum line width
+  return Math.max(width, LINE_WIDTH_MIN);
 };


### PR DESCRIPTION
MediaPipe Pose doesn't make it trivial to calculate the depth from the camera: https://github.com/google/mediapipe/issues/1611#issuecomment-974941821 This is better than before, as turning to the side would make the skeletons disappear.